### PR TITLE
Patch jax tree_util.tree_map interface

### DIFF
--- a/neuralgcm/api.py
+++ b/neuralgcm/api.py
@@ -533,7 +533,7 @@ class PressureLevelModel:
       assert isinstance(times, jax.Array)
       approx_index = jnp.interp(sim_time, times, jnp.arange(times.size))
       index = jnp.round(approx_index).astype(jnp.int32)
-      return jax.tree.map(lambda x: x[index, ...], forcings)
+      return jax.tree_util.tree_map(lambda x: x[index, ...], forcings)
 
     def with_nearest_forcings(func):
       def wrapped(state):

--- a/neuralgcm/transforms.py
+++ b/neuralgcm/transforms.py
@@ -130,12 +130,15 @@ class InverseShiftAndNormalize(hk.Module):
     # an error, as expected. This works because tree_map skips `None` values in
     # the first argument, as long as all dictionary keys match.
     result = jax.tree_util.tree_map(
-        lambda x, y, z: (None if x is None else x * z + y),
-        inputs,
-        shifts,
-        scales,
-        is_leaf=lambda x: x is None,
+      lambda x, y, z: None if x is None else (x * z + y),
+      inputs, 
+      shifts, 
+      scales,
+      is_leaf=lambda x: x is None
     )
+
+    # result = jax.tree_util.tree_map(
+    #     lambda x, y, z: x * z + y, inputs, shifts, scales)
     return from_dict_fn(result)
 
 
@@ -450,7 +453,7 @@ class HardClip(hk.Module):
     del coords, dt, physics_specs, aux_features  # unused.
     super().__init__(name=name)
     self.clip_fn = functools.partial(
-        jnp.clip, min=-max_value, max=max_value)
+        jnp.clip, a_min=-max_value, a_max=max_value)
 
   def __call__(self, inputs: typing.Pytree) -> typing.Pytree:
     return jax.tree_util.tree_map(self.clip_fn, inputs)

--- a/neuralgcm/transforms.py
+++ b/neuralgcm/transforms.py
@@ -130,11 +130,11 @@ class InverseShiftAndNormalize(hk.Module):
     # an error, as expected. This works because tree_map skips `None` values in
     # the first argument, as long as all dictionary keys match.
     result = jax.tree_util.tree_map(
-      lambda x, y, z: None if x is None else x * z + y,
-      inputs,
-      shifts,
-      scales,
-      is_leaf=lambda x: x is None
+        lambda x, y, z: (None if x is None else x * z + y),
+        inputs,
+        shifts,
+        scales,
+        is_leaf=lambda x: x is None,
     )
     return from_dict_fn(result)
 
@@ -450,7 +450,7 @@ class HardClip(hk.Module):
     del coords, dt, physics_specs, aux_features  # unused.
     super().__init__(name=name)
     self.clip_fn = functools.partial(
-        jnp.clip, a_min=-max_value, a_max=max_value)
+        jnp.clip, min=-max_value, max=max_value)
 
   def __call__(self, inputs: typing.Pytree) -> typing.Pytree:
     return jax.tree_util.tree_map(self.clip_fn, inputs)

--- a/neuralgcm/transforms.py
+++ b/neuralgcm/transforms.py
@@ -130,15 +130,12 @@ class InverseShiftAndNormalize(hk.Module):
     # an error, as expected. This works because tree_map skips `None` values in
     # the first argument, as long as all dictionary keys match.
     result = jax.tree_util.tree_map(
-      lambda x, y, z: None if x is None else (x * z + y),
-      inputs, 
-      shifts, 
+      lambda x, y, z: None if x is None else x * z + y,
+      inputs,
+      shifts,
       scales,
       is_leaf=lambda x: x is None
     )
-
-    # result = jax.tree_util.tree_map(
-    #     lambda x, y, z: x * z + y, inputs, shifts, scales)
     return from_dict_fn(result)
 
 


### PR DESCRIPTION
Running forecasting as in the docs with the latest jax deps fails due to the interface change in ` jax.tree_util.tree_map` in `transforms.py`. Patching as recommended in the error message:

```
In previous releases of JAX, flatten-up-to used to consider None to be a tree-prefix of non-None values. To obtain the previous behavior, you can usually write:
jax.tree.map(lambda x, y: None if x is None else f(x, y), a, b, is_leaf=lambda x: x is None)
```