### PR TITLE
fix(security): pin etils-actions/pypi-auto-publish and other Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci-legacy.yml
+++ b/.github/workflows/ci-legacy.yml
@@ -19,13 +19,13 @@ jobs:
         python-version: ["3.10", "3.11"]
     steps:
     - name: Cancel previous
-      uses: styfle/cancel-workflow-action@0.7.0
+      uses: styfle/cancel-workflow-action@d7e57e26a6f753933f8ef746a37097a61375236b # 0.7.0
       with:
         access_token: ${{ github.token }}
       if: ${{github.ref != 'refs/head/main'}}
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/publish-job.yml
+++ b/.github/workflows/publish-job.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     # Publish the package (if local `__version__` > pip version)
-    - uses: etils-actions/pypi-auto-publish@v1
+    - uses: etils-actions/pypi-auto-publish@e3c4b4afc3a5b12a44734da938741995538e8223 # v1
       with:
         pypi-token: ${{ secrets.PYPI_API_TOKEN }}
         gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This workflow uses **mutable tag references** for GitHub Actions including `etils-actions/pypi-auto-publish@v1` — a third-party action. If the tag is silently redirected, malicious code runs in the job holding `PYPI_API_TOKEN`, enabling a supply-chain attack on every downstream user.

## Fix

All action references pinned to immutable commit SHAs. Follows the [GitHub security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).